### PR TITLE
fix(netlify): Handle nested TMDB endpoint paths

### DIFF
--- a/app/netlify/functions/tmdb.js
+++ b/app/netlify/functions/tmdb.js
@@ -12,13 +12,14 @@ app.use(express.json());
 const TMDB_BEARER_TOKEN = process.env.TMDB_BEARER_TOKEN;
 const TMDB_BASE_URL = process.env.TMDB_BASE_URL || process.env.TMDB_API_URL;
 
-app.get('/api/tmdb/:endpoint', async (req, res) => {
+app.get('/api/tmdb/*', async (req, res) => {
   if (!TMDB_BASE_URL || !TMDB_BEARER_TOKEN) {
     return res.status(500).json({ error: 'TMDB server configuration is missing.' });
   }
 
   try {
-    const response = await axios.get(`${TMDB_BASE_URL}/${req.params.endpoint}`, {
+    const tmdbPath = req.params[0];
+    const response = await axios.get(`${TMDB_BASE_URL}/${tmdbPath}`, {
       headers: { Authorization: `Bearer ${TMDB_BEARER_TOKEN}` },
       params: req.query,
     });


### PR DESCRIPTION
- Update the Netlify function route to accept dynamic nested TMDB paths instead of a single path segment.

- Prevent production 404s for requests like search/movie and movie/:id/credits.