### PR TITLE
fix(netlify): Support both TMDB proxy route shapes

### DIFF
--- a/app/netlify/functions/tmdb.js
+++ b/app/netlify/functions/tmdb.js
@@ -12,13 +12,12 @@ app.use(express.json());
 const TMDB_BEARER_TOKEN = process.env.TMDB_BEARER_TOKEN;
 const TMDB_BASE_URL = process.env.TMDB_BASE_URL || process.env.TMDB_API_URL;
 
-app.get('/api/tmdb/*', async (req, res) => {
+const proxyTmdb = async (req, res, tmdbPath) => {
   if (!TMDB_BASE_URL || !TMDB_BEARER_TOKEN) {
     return res.status(500).json({ error: 'TMDB server configuration is missing.' });
   }
 
   try {
-    const tmdbPath = req.params[0];
     const response = await axios.get(`${TMDB_BASE_URL}/${tmdbPath}`, {
       headers: { Authorization: `Bearer ${TMDB_BEARER_TOKEN}` },
       params: req.query,
@@ -29,6 +28,14 @@ app.get('/api/tmdb/*', async (req, res) => {
     console.error('Erro ao buscar dados do TMDb:', error);
     res.status(500).json({ error: 'Erro ao buscar dados do TMDb' });
   }
+};
+
+app.get('/api/tmdb/*', async (req, res) => {
+  return proxyTmdb(req, res, req.params[0]);
+});
+
+app.get('/*', async (req, res) => {
+  return proxyTmdb(req, res, req.params[0]);
 });
 
 module.exports.handler = serverless(app);


### PR DESCRIPTION
- Accept requests with and without the /api/tmdb prefix in the Netlify function path.
- Prevent 404 responses when VITE_API_URL is configured as /.netlify/functions/tmdb.