### PR TITLE
Fix desktop sidebar collapse

### DIFF
--- a/app/src/layouts/MainLayout.vue
+++ b/app/src/layouts/MainLayout.vue
@@ -133,7 +133,7 @@ export default defineComponent({
     const leftDrawerOpen = ref(true);
     const headerSearch = ref("");
     const searchValidationMessage = ref("");
-    const miniState = ref(false);
+    const miniState = ref(true);
     const hasSearchToClear = computed(() =>
       Boolean(
         headerSearch.value.trim() ||
@@ -176,7 +176,7 @@ export default defineComponent({
         }
 
         leftDrawerOpen.value = true;
-        miniState.value = false;
+        miniState.value = true;
       },
       { immediate: true }
     );
@@ -193,10 +193,14 @@ export default defineComponent({
       miniState,
       t,
       handleDrawerMouseEnter() {
-        miniState.value = false;
+        if (!isMobile.value) {
+          miniState.value = false;
+        }
       },
       handleDrawerMouseLeave() {
-        miniState.value = false;
+        if (!isMobile.value) {
+          miniState.value = true;
+        }
       },
       toggleLeftDrawer() {
         if (!isMobile.value) {

--- a/app/test/cypress/e2e/navigation.cy.js
+++ b/app/test/cypress/e2e/navigation.cy.js
@@ -1,4 +1,11 @@
 describe('core navigation', () => {
+  it('collapses the desktop sidebar until hover', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/');
+
+    cy.get('.q-drawer').should('have.class', 'q-drawer--mini');
+  });
+
   it('marks only the current sidebar route as active', () => {
     cy.viewport(1440, 900);
     cy.visit('/about');

--- a/app/test/vitest/__tests__/MainLayout.test.js
+++ b/app/test/vitest/__tests__/MainLayout.test.js
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import MainLayout from '../../../src/layouts/MainLayout.vue';
+
+const push = vi.fn();
+let isMobile = false;
+let routeQuery = {};
+
+vi.mock('quasar', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...actual,
+    useQuasar: () => ({
+      screen: {
+        get lt() {
+          return {
+            md: isMobile,
+          };
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    path: '/',
+    query: routeQuery,
+    meta: {
+      titleKey: 'navigation.search',
+    },
+  }),
+  useRouter: () => ({
+    push,
+  }),
+}));
+
+vi.mock('../../../src/composables/useTranslations', () => ({
+  useTranslations: () => ({
+    t: (key) => (
+      {
+        'layout.tagline': '1 movie per day of year, or almost it',
+        'navigation.search': 'Movie search',
+        'navigation.agenda': 'Agenda',
+        'navigation.challenge': 'Challenge',
+        'navigation.about': 'About',
+        'navigation.settings': 'Settings',
+        'settings.search.placeholder': 'Type movie title... And press Enter',
+        'settings.actions.lucky': "I'm lucky",
+        'settings.actions.clearSearch': 'Clear search',
+        'settings.search.invalid': 'Please type at least 3 letters.',
+      }[key] || key
+    ),
+  }),
+}));
+
+const layoutStubs = {
+  'q-layout': {
+    template: '<div><slot /></div>',
+  },
+  'q-header': {
+    template: '<header><slot /></header>',
+  },
+  'q-toolbar': {
+    template: '<div><slot /></div>',
+  },
+  'q-toolbar-title': {
+    template: '<div><slot /></div>',
+  },
+  'q-btn': {
+    template: '<button type="button"><slot /></button>',
+  },
+  'q-form': {
+    template: '<form><slot /></form>',
+  },
+  'q-input': {
+    template: '<input />',
+  },
+  'q-icon': {
+    template: '<span />',
+  },
+  'q-tooltip': {
+    template: '<span><slot /></span>',
+  },
+  'q-drawer': {
+    props: ['modelValue', 'mini'],
+    template: '<aside class="q-drawer" :class="{ \'q-drawer--mini\': mini }"><slot /></aside>',
+  },
+  'q-list': {
+    template: '<nav><slot /></nav>',
+  },
+  'q-item-label': {
+    template: '<span><slot /></span>',
+  },
+  'q-item': {
+    template: '<a><slot /></a>',
+  },
+  'q-item-section': {
+    template: '<span><slot /></span>',
+  },
+  'q-page-container': {
+    template: '<main><slot /></main>',
+  },
+  'router-view': {
+    template: '<section />',
+  },
+};
+
+const mountLayout = () =>
+  mount(MainLayout, {
+    global: {
+      stubs: layoutStubs,
+    },
+  });
+
+describe('MainLayout', () => {
+  beforeEach(() => {
+    isMobile = false;
+    routeQuery = {};
+    push.mockReset();
+    sessionStorage.clear();
+    document.documentElement.scrollTop = 0;
+  });
+
+  it('keeps the desktop drawer collapsed until hover', async () => {
+    const wrapper = mountLayout();
+    const drawer = wrapper.get('.q-drawer');
+
+    expect(drawer.classes()).toContain('q-drawer--mini');
+
+    await drawer.trigger('mouseenter');
+    expect(drawer.classes()).not.toContain('q-drawer--mini');
+
+    await drawer.trigger('mouseleave');
+    expect(drawer.classes()).toContain('q-drawer--mini');
+  });
+});


### PR DESCRIPTION
## Summary
- Restores the desktop sidebar mini drawer behavior.
- Keeps the drawer collapsed on desktop until hover.
- Restores hover expansion and mouseleave collapse without changing mobile drawer behavior.

## Root Cause
- The 2.6.0 layout changes initialized `miniState` as `false`.
- The desktop breakpoint watcher also forced `miniState` to `false`.
- The drawer mouseleave handler kept `miniState` as `false`, so the sidebar could not return to its collapsed state.

## Validation
- `docker exec 365movies_ctn yarn vitest run test/vitest/__tests__/MainLayout.test.js`
- `docker exec 365movies_ctn sh -lc 'CYPRESS_CACHE_FOLDER=.cache/Cypress yarn cypress run --e2e --spec test/cypress/e2e/navigation.cy.js'`
